### PR TITLE
test for edit button visibility for news author

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <selenium-java.version>4.30.0</selenium-java.version>
+        <selenium-java.version>4.33.0</selenium-java.version>
         <lombok.version>1.18.36</lombok.version>
         <testng.version>7.10.2</testng.version>
         <webdrivermanager.version>6.1.0</webdrivermanager.version>

--- a/src/test/java/com/greencity/ui/CancelEditingTest.java
+++ b/src/test/java/com/greencity/ui/CancelEditingTest.java
@@ -1,14 +1,15 @@
-package com.greencity.ui.testrunners;
+package com.greencity.ui;
 
-import com.greencity.ui.pages.abstractNewsPage.NewsPage;
 import com.greencity.ui.pages.econewspage.EcoNewsPage;
 import com.greencity.ui.pages.homepage.HomePage;
+import com.greencity.ui.testrunners.TestRunnerWithUser;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class CancelEditingTest extends TestRunnerWithUser {
     @Test
     public void declineEditTitle() {
+
         driver.get(testValueProvider.getBaseUIUrl() + "/profile");
 
 
@@ -27,6 +28,6 @@ public class CancelEditingTest extends TestRunnerWithUser {
 
         String currentTitle = new EcoNewsPage(driver).getNewsCards().getFirst().getText();
 
-       Assert.assertEquals(currentTitle, originalNewsTitle, "Title was changed after canceling editing.");
+       Assert.assertEquals(currentTitle,originalNewsTitle,"Title was changed after cancel editing. Original title was: " + originalNewsTitle + "Current title is: " + currentTitle);
     }
 }

--- a/src/test/java/com/greencity/ui/EditButtonVisibilityTest.java
+++ b/src/test/java/com/greencity/ui/EditButtonVisibilityTest.java
@@ -1,0 +1,22 @@
+package com.greencity.ui;
+
+import com.greencity.ui.pages.abstractNewsPage.NewsPage;
+import com.greencity.ui.pages.econewspage.EcoNewsPage;
+import com.greencity.ui.testrunners.TestRunnerWithUser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class EditButtonVisibilityTest extends TestRunnerWithUser {
+    @Test
+    public void verifyEditButtonVisibleOnlyForAuthor() {
+        driver.get(testValueProvider.getBaseUIUrl() + "/profile");
+
+        EcoNewsPage ecoNewsPage = new EcoNewsPage(driver).getHeader().goToEcoNews();
+
+        NewsPage newsPage = ecoNewsPage.clickFirstNewsPage();
+
+        boolean isEditButtonVisible = newsPage.getEditNewsButton().isDisplayed();
+
+        Assert.assertTrue(isEditButtonVisible, "Edit button is not visible.");
+    }
+}

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,7 @@
+# log4j.properties
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{HH:mm:ss} %-5p %c{1}:%L - %m%n

--- a/testng.xml
+++ b/testng.xml
@@ -6,7 +6,7 @@
         <classes>
             <class name="com.greencity.ui.testrunners.BaseTestRunner"/>
             <class name="com.greencity.ui.testrunners.TestRunnerWithUser"/>
-            <class name="com.greencity.ui.testrunners.CancelEditingTest"/>
+            <class name="com.greencity.ui.CancelEditingTest"/>
         </classes>
     </test>
 </suite>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new test to verify that the "Edit" button is visible only to the author of a news item.
  - Introduced a log configuration file for improved console logging during test execution.

- **Bug Fixes**
  - Enhanced assertion messages in the cancel editing test for clearer test failure details.

- **Chores**
  - Updated Selenium Java dependency to version 4.33.0.
  - Adjusted package references and imports in test classes for consistency.
  - Updated test configuration to reflect package changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->