### PR TITLE
Navigate EcoNews page verify layout test. EcoNews page add selectors

### DIFF
--- a/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
@@ -69,6 +69,9 @@ public class CreateEditNewsPage extends BasePage {
     @FindBy(xpath = "//p[contains(@class,'field-info')]")
     private WebElement contentInfoMessage;
 
+    @FindBy(xpath = "//span[@class = 'span field-info warning']")
+    private WebElement sourceErrorMessage;
+
     public CreateEditNewsPage enterTitle(String title) {
         titleInput.clear();
         titleInput.sendKeys(title);

--- a/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
@@ -42,6 +42,8 @@ public class EcoNewsPage extends BasePage {
     }
 
     public CreateEditNewsPage clickCreateNewsButton() {
+        scrollToElement(createNewsButton);
+        waitUntilElementClickable(createNewsButton);
         createNewsButton.click();
         return new CreateEditNewsPage(driver);
     }

--- a/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
@@ -15,17 +15,27 @@ import java.util.List;
 @Getter
 public class EcoNewsPage extends BasePage {
 
-    @FindBy(xpath = ".//h1[contains(@class, 'main-header')]")
+    @FindBy(xpath = "//h1[contains(@class, 'main-header')]")
     private WebElement title;
 
-    @FindBy(xpath = ".//button[contains(@class, 'tag-button')]")
-    private List<WebElement> tags;
+    @FindBy(xpath = "//button[contains(@class, 'tag-button')]")
+    private List<WebElement> filteringOptions;
 
     @FindBy(xpath = "//div[@id='create-button']")
     private WebElement createNewsButton;
 
     @FindBy(xpath = "//li[contains(@class,'gallery-view-li')]")
     private List<WebElement> newsCards;
+
+    @FindBy(xpath = "//div[@class='header_navigation-menu']")
+    private WebElement navigationPanel;
+
+    @FindBy(xpath = "//span[@aria-label='table view']")
+    private WebElement galleryView;
+
+    @FindBy(xpath = "//span[@aria-label='list view']")
+    private WebElement listView;
+
 
     public EcoNewsPage(WebDriver driver) {
         super(driver);
@@ -47,5 +57,6 @@ public class EcoNewsPage extends BasePage {
                 .map(el -> new NewsComponent(driver, el))
                 .toList();
     }
+
 
 }

--- a/src/test/java/com/greencity/ui/NavigateEcoNewsPageAndLayoutTest.java
+++ b/src/test/java/com/greencity/ui/NavigateEcoNewsPageAndLayoutTest.java
@@ -2,11 +2,10 @@ package com.greencity.ui;
 
 import com.greencity.ui.pages.econewspage.EcoNewsPage;
 import com.greencity.ui.testrunners.TestRunnerWithUser;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.asserts.SoftAssert;
 
-public class NevigateEcoNewsPageAndLayoutTest extends TestRunnerWithUser {
+public class NavigateEcoNewsPageAndLayoutTest extends TestRunnerWithUser {
 
     @Test
     public void verifyNavigateToEcoNewsPageAndLayoutAnauthorized() {
@@ -20,7 +19,7 @@ public class NevigateEcoNewsPageAndLayoutTest extends TestRunnerWithUser {
         SoftAssert softAssert = new SoftAssert();
 
 //Use assertions to verify that the current URL includes /news or expected route.
-        assert currentUrl != null;
+        softAssert.assertNotNull(currentUrl, "Current URL should not be null");
         softAssert.assertTrue(currentUrl.contains("/news"), "Current url does not contain '/news'");
 
 //Check presence of header, footer, and nav elements using known selectors.
@@ -46,11 +45,15 @@ public class NevigateEcoNewsPageAndLayoutTest extends TestRunnerWithUser {
     public void verifyNavigateToEcoNewsPageAndLayoutWithUser()  {
         driver.get(testValueProvider.getBaseUIUrl() + "/profile");
 
-        EcoNewsPage ecoNewsPage = new EcoNewsPage(driver).getHeader().goToEcoNews();
+        EcoNewsPage ecoNewsPage = homePage
+                .getHeader()
+                .goToEcoNews();
 
-        boolean isCreateButtonVisible = ecoNewsPage.getCreateNewsButton().isDisplayed();
-
-        Assert.assertTrue(isCreateButtonVisible, "Create button is not visible.");
+        String currentUrl = driver.getCurrentUrl();
+        SoftAssert softAssert = new SoftAssert();
+        softAssert.assertTrue(currentUrl.contains("/news"), "Current url does not contain '/news'");
+        softAssert.assertTrue(ecoNewsPage.getCreateNewsButton().isDisplayed(), "Create button is not visible.");
+        softAssert.assertAll();
     }
 }
 

--- a/src/test/java/com/greencity/ui/NevigateEcoNewsPageAndLayoutTest.java
+++ b/src/test/java/com/greencity/ui/NevigateEcoNewsPageAndLayoutTest.java
@@ -1,0 +1,56 @@
+package com.greencity.ui;
+
+import com.greencity.ui.pages.econewspage.EcoNewsPage;
+import com.greencity.ui.testrunners.TestRunnerWithUser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+public class NevigateEcoNewsPageAndLayoutTest extends TestRunnerWithUser {
+
+    @Test
+    public void verifyNavigateToEcoNewsPageAndLayoutAnauthorized() {
+        driver.get(testValueProvider.getBaseUIUrl());
+        EcoNewsPage ecoNewsPage = homePage
+                .getHeader()
+                .goToEcoNews();
+
+        String currentUrl = driver.getCurrentUrl();
+
+        SoftAssert softAssert = new SoftAssert();
+
+//Use assertions to verify that the current URL includes /news or expected route.
+        assert currentUrl != null;
+        softAssert.assertTrue(currentUrl.contains("/news"), "Current url does not contain '/news'");
+
+//Check presence of header, footer, and nav elements using known selectors.
+        softAssert.assertTrue(ecoNewsPage.getHeader().getRootElement().isDisplayed(), "Header is not visible");
+        softAssert.assertTrue(ecoNewsPage.getFooter().getRootElement().isDisplayed(), "Footer is not visible");
+        softAssert.assertTrue(ecoNewsPage.getNavigationPanel().isDisplayed(), "Navigation panel is not visible");
+
+//Assert that page title text equals "Eco news".
+        softAssert.assertEquals(ecoNewsPage.getTitle().getText(),"Eco news", "Page title is not as expected. Expected: Eco News. But Actual tile is: " + ecoNewsPage.getTitle().getText());
+
+//Locate and verify visibility of the filter controls, "Create" button, and toggle options for gallery and list view.
+        softAssert.assertTrue(!ecoNewsPage.getFilteringOptions().isEmpty(), "Filtering options are not visible or empty.");
+        softAssert.assertTrue(ecoNewsPage.getListView().isDisplayed(), "List view button is not visible");
+        softAssert.assertTrue(ecoNewsPage.getGalleryView().isDisplayed(), "Gallery view button is not visible");
+
+        softAssert.assertTrue(!ecoNewsPage.getNewsCards().isEmpty(), "No news cards are displayed.");
+
+        softAssert.assertAll();
+
+    }
+
+    @Test
+    public void verifyNavigateToEcoNewsPageAndLayoutWithUser()  {
+        driver.get(testValueProvider.getBaseUIUrl() + "/profile");
+
+        EcoNewsPage ecoNewsPage = new EcoNewsPage(driver).getHeader().goToEcoNews();
+
+        boolean isCreateButtonVisible = ecoNewsPage.getCreateNewsButton().isDisplayed();
+
+        Assert.assertTrue(isCreateButtonVisible, "Create button is not visible.");
+    }
+}
+

--- a/src/test/java/com/greencity/ui/SourceFieldValidationTest.java
+++ b/src/test/java/com/greencity/ui/SourceFieldValidationTest.java
@@ -1,0 +1,46 @@
+package com.greencity.ui;
+
+import com.greencity.ui.elements.NewsTags;
+import com.greencity.ui.pages.CreateEditNewsPage;
+import com.greencity.ui.pages.econewspage.EcoNewsPage;
+import com.greencity.ui.testrunners.TestRunnerWithUser;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+public class SourceFieldValidationTest extends TestRunnerWithUser {
+    @Test
+    public void sourceFieldValidation() {
+        driver.get(testValueProvider.getBaseUIUrl() + "/profile");
+        String currentTitle = homePage
+                .getHeader()
+                .goToEcoNews()
+                .clickCreateNewsButton()
+                .enterTitle("Source test")
+                .clickTag(NewsTags.EDUCATION_TAG)
+                .enterContent("Source test content text to 20 chars")
+                .clickPublish().getNewsComponents().getFirst().getTitle().getText();
+
+
+        SoftAssert softAssert = new SoftAssert();
+        softAssert.assertEquals(currentTitle, "Source test","Current title is not as expected.");
+
+        CreateEditNewsPage createEditNewsPage = new EcoNewsPage(driver)
+                //org.openqa.selenium.ElementClickInterceptedException: element click intercepted: Element <div _ngcontent-ng-c3257706870="" id="create-button" class="secondary-global-button m-btn">...</div> is not clickable at point (1140, 15).
+                // Other element would receive the click: <li _ngcontent-ng-c113581887="" role="option" aria-label="english" tabindex="0" class="lang-option">...</li>
+                .clickCreateNewsButton()
+                .enterTitle("Source test with source")
+                .clickTag(NewsTags.EDUCATION_TAG)
+                .enterContent("Source test content text to 20 chars")
+                .enterSource("www.example.com");
+
+
+        softAssert.assertTrue(createEditNewsPage.getSourceErrorMessage().isDisplayed());
+        softAssert.assertFalse(createEditNewsPage.getPublishButton().isEnabled());
+
+        createEditNewsPage.enterSource("https://example.com").clickPublish();
+        String withSourceTitle = new EcoNewsPage(driver).getNewsComponents().getFirst().getTitle().getText();
+        softAssert.assertEquals(withSourceTitle, "Source test with source","Current title is not as expected.");
+
+        softAssert.assertAll();
+    }
+}


### PR DESCRIPTION
Navigate EcoNews page verify layout test. EcoNews page add selectors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added new tests to validate the source field in news creation and to verify navigation and layout of the Eco News page for both authorized and unauthorized users.

- **Bug Fixes**
  - Improved reliability of the "Create News" button by ensuring it is visible and clickable before interaction.

- **Refactor**
  - Updated naming of filtering options for better clarity.
  - Enhanced selectors for improved element targeting on the Eco News page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->