### PR TITLE
#96 [EcoNews Page] [Test Case] Display of recommended news when no tag filter is applied

### DIFF
--- a/src/main/java/com/greencity/ui/components/NewsComponent.java
+++ b/src/main/java/com/greencity/ui/components/NewsComponent.java
@@ -31,19 +31,6 @@ public class NewsComponent extends BaseComponent {
         super(driver, rootElement);
     }
 
-//    private final WebElement title;
-//    private final WebElement image;
-//    @Getter
-//    private final List<WebElement> tags;
-//    private final WebElement publicationDate;
-//
-//    public NewsComponent(WebDriver driver, WebElement rootElement) {
-//        super(driver, rootElement);
-//        this.title = rootElement.findElement(By.xpath(".//div[@class='title-list word-wrap']"));
-//        this.image = rootElement.findElement(By.xpath(".//img[@class='list-image-content']"));
-//        this.tags = rootElement.findElements(By.xpath(".//div[@class='filter-tag']"));
-//        this.publicationDate = rootElement.findElement(By.xpath(".//p[contains(@class, 'user-data-text-date')]/span"));
-//    }
 
     public String getTitleText() {
         return title.getText().trim();

--- a/src/test/java/com/greencity/ui/InterestingNewsWidgetTest.java
+++ b/src/test/java/com/greencity/ui/InterestingNewsWidgetTest.java
@@ -20,7 +20,7 @@ public class InterestingNewsWidgetTest extends TestRunnerWithUser {
                 .getHeader()
                 .goToEcoNews();
 
-        boolean anyTagActive = ecoNewsPage.getTags().stream()
+        boolean anyTagActive = ecoNewsPage.getFilteringOptions().stream()
                 .anyMatch(tag -> tag.getAttribute("class").contains("active"));
         softAssert.assertFalse(anyTagActive, "No tag filter should be active.");
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added the ability to view the publication date for news items.
	- Enabled clicking on news titles to open detailed views.
- **Bug Fixes**
	- Improved accuracy of recommended news by ensuring the three most recent items are displayed, regardless of tag filters.
- **Tests**
	- Introduced a new test to verify the correct behavior of the "Interesting News" widget, including sorting and exclusion of the currently viewed news item.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->