### PR TITLE
[Edit News]Validation – image size >10MB

### DIFF
--- a/src/main/java/com/greencity/ui/components/header/HeaderComponent.java
+++ b/src/main/java/com/greencity/ui/components/header/HeaderComponent.java
@@ -2,7 +2,10 @@ package com.greencity.ui.components.header;
 
 import com.greencity.ui.components.baseComponents.BaseComponent;
 import com.greencity.ui.pages.econewspage.EcoNewsPage;
+import com.greencity.ui.pages.myspacepage.MySpacePage;
 import lombok.Getter;
+import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
@@ -16,10 +19,15 @@ public class HeaderComponent extends BaseComponent {
     @FindBy(css = "a[href='#/greenCity/news'].url-name")
     private WebElement ecoNewsLink;
 
-    @FindBy(xpath = "//div[@class = 'header_navigation-menu']")
+    @FindBy(xpath = ".//a[contains(@href, '#/greenCity/profile')]")
+    private WebElement mySpaceLink;
+
+    private final String mySpaceLinkXPath = ".//a[contains(@href, '#/greenCity/profile')]";
+
+    @FindBy(xpath = ".//div[@class = 'header_navigation-menu']")
     private WebElement modalRoot;
 
-    @FindBy(xpath = "//li[contains(@class,'user-name')]")
+    @FindBy(xpath = ".//li[contains(@class,'user-name')]")
     private WebElement loggedInUserName;
 
     public String getLoggedInUserName() {
@@ -35,4 +43,17 @@ public class HeaderComponent extends BaseComponent {
         ecoNewsLink.click();
         return new EcoNewsPage(driver);
     }
+
+    public MySpacePage goToMySpace() {
+        try {
+            waitUntilElementClickable(mySpaceLink);
+            mySpaceLink.click();
+        } catch (StaleElementReferenceException e) {
+            WebElement newMySpaceLink = driver.findElement(By.xpath(getMySpaceLinkXPath()));
+            waitUntilElementClickable(newMySpaceLink);
+            newMySpaceLink.click();
+        }
+        return new MySpacePage(driver);
+    }
+
 }

--- a/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
@@ -110,8 +110,9 @@ public class CreateEditNewsPage extends BasePage {
         return this;
     }
 
-    public void uploadImage(String filePath) {
+    public CreateEditNewsPage uploadImage(String filePath) {
         browserLink.sendKeys(filePath);
+        return this;
     }
 
     public CreateEditNewsPage clickSubmitImage() {

--- a/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
@@ -39,6 +39,9 @@ public class NewsPage extends AbstractNewsPage {
 
     private final By dialogPopUpRoot = By.xpath("//app-dialog-pop-up");
 
+    @FindBy(xpath = "//img[contains(@class, 'news-image-img')]")
+    private WebElement newsImage;
+
     public NewsPage(WebDriver driver) {
         super(driver);
     }

--- a/src/main/java/com/greencity/ui/pages/myspacepage/MySpacePage.java
+++ b/src/main/java/com/greencity/ui/pages/myspacepage/MySpacePage.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 
 @Getter
 public class MySpacePage extends BasePage {
@@ -39,8 +40,10 @@ public class MySpacePage extends BasePage {
     }
 
     public NewsPage clickFirstNew(){
-        listOfNews = driver.findElements(newsListInMyNewsTab);
-        listOfNews.getFirst().click();
+        if (listOfNews.isEmpty()) {
+            throw new NoSuchElementException("No news found in 'My news' tab");
+        }
+        listOfNews.get(0).click();
         return new NewsPage(driver);
     }
 }

--- a/src/main/java/com/greencity/ui/pages/myspacepage/MySpacePage.java
+++ b/src/main/java/com/greencity/ui/pages/myspacepage/MySpacePage.java
@@ -1,18 +1,46 @@
 package com.greencity.ui.pages.myspacepage;
 
 import com.greencity.ui.pages.BasePage;
+import com.greencity.ui.pages.CreateEditNewsPage;
+import com.greencity.ui.pages.abstractNewsPage.NewsPage;
 import lombok.Getter;
+import org.openqa.selenium.By;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.WebElement;
 import org.openqa.selenium.support.FindBy;
+
+import java.util.List;
 
 @Getter
 public class MySpacePage extends BasePage {
 
     @FindBy(xpath = "//div[@class='description']/div[2]")
-    WebElement mySpaceDescription;
+    private WebElement mySpaceDescription;
+
+    @FindBy(xpath = "//div[contains(@id, 'mat-tab-label')]")
+    private List<WebElement> matTabs;
+
+    private final By newsListInMyNewsTab = By.xpath("//app-one-news");
+    private List<WebElement> listOfNews;
+
 
     public MySpacePage(WebDriver driver) {
         super(driver);
+    }
+
+    public MySpacePage clickTabsByText(String name){
+        for (WebElement tab : matTabs) {
+            if (tab.getText().contains(name)){
+                tab.click();
+                break;
+            }
+        }
+        return this;
+    }
+
+    public NewsPage clickFirstNew(){
+        listOfNews = driver.findElements(newsListInMyNewsTab);
+        listOfNews.getFirst().click();
+        return new NewsPage(driver);
     }
 }

--- a/src/test/java/com/greencity/ui/ecoNewsTests/editNewsTests/ValidationEditPageImageSize.java
+++ b/src/test/java/com/greencity/ui/ecoNewsTests/editNewsTests/ValidationEditPageImageSize.java
@@ -1,0 +1,33 @@
+package com.greencity.ui.ecoNewsTests.editNewsTests;
+
+import com.greencity.ui.testrunners.TestRunnerWithUser;
+import org.testng.annotations.Test;
+import org.testng.asserts.SoftAssert;
+
+import java.io.File;
+
+public class ValidationEditPageImageSize  extends TestRunnerWithUser {
+
+    @Test
+    public void editNewsImageUpload_ShouldNotAllowImagesGreaterThan10MB(){
+        SoftAssert softAssert = new SoftAssert();
+        File image = new File("src/test/resources/imagesForTests/15mb.jpg");
+        String imageSrc = homePage
+                .getHeader()
+                .goToMySpace()
+                .clickTabsByText("My news")
+                .clickFirstNew()
+                .clickEditNewsButton()
+                .uploadImage(image.getAbsolutePath())
+                .clickPublish()
+                .getHeader()
+                .goToMySpace()
+                .clickTabsByText("My news")
+                .clickFirstNew()
+                .getNewsImage()
+                .getAttribute("src");
+
+        softAssert.assertTrue(imageSrc.contains("assets/img/icon/econews/news-default-large.png"), "Image was changed");
+        softAssert.assertAll();
+    }
+}


### PR DESCRIPTION
implemented ValidationEditPageImageSize, updated other classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added navigation to the "My Space" page from the header.
  - Enabled tab navigation and news item selection within the "My Space" page.
  - Display of news images is now supported on news pages.

- **Enhancements**
  - Improved method chaining when uploading images during news creation or editing.

- **Tests**
  - Introduced a test to ensure that uploading images larger than 10MB when editing news is not allowed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->