### PR TITLE
Tag selection test update

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
-        <selenium-java.version>4.33.0</selenium-java.version>
+        <selenium-java.version>4.34.0</selenium-java.version>
         <lombok.version>1.18.36</lombok.version>
         <testng.version>7.10.2</testng.version>
         <webdrivermanager.version>6.1.0</webdrivermanager.version>

--- a/src/main/java/com/greencity/ui/elements/NewsTags.java
+++ b/src/main/java/com/greencity/ui/elements/NewsTags.java
@@ -36,4 +36,13 @@ public enum NewsTags {
         return false;
     }
 
+    public static NewsTags getByName(String name) {
+        for (NewsTags tag : NewsTags.values()) {
+            if (tag.getEnglishName().equalsIgnoreCase(name) || tag.getUkrainianName().equalsIgnoreCase(name)) {
+                return tag;
+            }
+        }
+        throw new IllegalArgumentException("No NewsTags with name: " + name);
+    }
+
 }

--- a/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
@@ -254,5 +254,9 @@ public class CreateEditNewsPage extends BasePage {
                 .collect(Collectors.toList());
     }
 
+    @Step("Get tag by name")
+    public WebElement getByName(String tag) {
+        return driver.findElement(By.xpath("//a[contains(@class,'global-tag') and text()='" + tag + "']"));
+    }
 
 }

--- a/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
@@ -248,7 +248,7 @@ public class CreateEditNewsPage extends BasePage {
     }
     @Step("Get selected tags")
     public List<String> getSelectedTags() {
-        return driver.findElements(By.cssSelector(".tags-select"))
+        return driver.findElements(By.xpath("//a[@class='global-tag global-tag-clicked']"))
                 .stream()
                 .map(WebElement::getText)
                 .collect(Collectors.toList());

--- a/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/CreateEditNewsPage.java
@@ -13,7 +13,6 @@ import org.openqa.selenium.support.FindBy;
 
 import java.util.List;
 import java.util.Random;
-import java.util.stream.Collectors;
 
 @Getter
 public class CreateEditNewsPage extends BasePage {
@@ -246,17 +245,22 @@ public class CreateEditNewsPage extends BasePage {
     public String getContentText() {
         return contentInput.getText().trim();
     }
-    @Step("Get selected tags")
-    public List<String> getSelectedTags() {
-        return driver.findElements(By.xpath("//a[@class='global-tag global-tag-clicked']"))
-                .stream()
-                .map(WebElement::getText)
-                .collect(Collectors.toList());
+
+    @Step("Get number of selected tags")
+    public int getSelectedTagCount() {
+        List<WebElement> selectedTags = driver.findElements(By.cssSelector(".global-tag.global-tag-clicked"));
+        return selectedTags.size();
     }
 
-    @Step("Get tag by name")
-    public WebElement getByName(String tag) {
-        return driver.findElement(By.xpath("//a[contains(@class,'global-tag') and text()='" + tag + "']"));
+    public boolean isTagSelected(NewsTags tag) {
+        List<WebElement> tags = driver.findElements(By.cssSelector(".global-tag"));
+        for (WebElement el : tags) {
+            if (el.getText().trim().equalsIgnoreCase(tag.toString())) {
+                String classAttr = el.getAttribute("class");
+                return classAttr != null && classAttr.contains("global-tag-clicked");
+            }
+        }
+        return false;
     }
 
 }

--- a/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
@@ -105,4 +105,19 @@ public class EcoNewsPage extends BasePage {
                 .toList();
     }
 
+    @Step("Get number of selected tag filters")
+    public int getSelectedTagCount() {
+        List<WebElement> selectedTags = driver.findElements(By.cssSelector(".custom-chip.global-tag.global-tag-clicked"));
+        return selectedTags.size();
+    }
+
+    public List<String> getSelectedTags() {
+        return driver.findElements(By.xpath("//div[contains(@class,'tags-list')]//a[contains(@class,'global-tag') and contains(@class,'global-tag-clicked') or contains(@class,'global-tag')]"))
+                .stream()
+                .map(WebElement::getText)
+                .toList();
+    }
+
+
+
 }

--- a/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/econewspage/EcoNewsPage.java
@@ -111,12 +111,6 @@ public class EcoNewsPage extends BasePage {
         return selectedTags.size();
     }
 
-    public List<String> getSelectedTags() {
-        return driver.findElements(By.xpath("//div[contains(@class,'tags-list')]//a[contains(@class,'global-tag') and contains(@class,'global-tag-clicked') or contains(@class,'global-tag')]"))
-                .stream()
-                .map(WebElement::getText)
-                .toList();
-    }
 
 
 

--- a/src/test/java/com/greencity/cucumber/hooks/Hooks.java
+++ b/src/test/java/com/greencity/cucumber/hooks/Hooks.java
@@ -18,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.asserts.SoftAssert;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.time.Duration;
@@ -87,6 +88,16 @@ public class Hooks {
             result = Files.readAllBytes(scrFile.toPath());
         } catch (IOException e) {
             e.printStackTrace();
+        }
+        String filePath = "target/" + attachName + ".png";
+        try (FileOutputStream fos = new FileOutputStream(filePath)) {
+            fos.write(result);
+            System.out.println("Зображення успішно збережено за шляхом: " + filePath);
+
+        } catch (IOException e) {
+            System.err.println("Помилка при збереженні зображення у файл " + filePath + ": " + e.getMessage());
+            e.printStackTrace();
+
         }
         return result;
     }

--- a/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
@@ -23,7 +23,7 @@ public class TagSelectionSteps {
 
     @Given("User opens the Create News page")
     public void userIsOnCreateNewsPage() {
-        hooks.getDriver().get(hooks.getTestValueProvider().getBaseUIUrl() + "/news/create");
+        hooks.getDriver().get(hooks.getTestValueProvider().getBaseUIUrl() + "/news/create-news");
         createEditNewsPage = getCreateEditNewsPage();
     }
 
@@ -54,6 +54,11 @@ public class TagSelectionSteps {
 
     @Then("User should see only 3 tags selected")
     public void verifyOnlyThreeTagsSelected() {
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
         createEditNewsPage = getCreateEditNewsPage();
         List<String> selectedTags = createEditNewsPage.getSelectedTags();
         hooks.getSoftAssert().assertEquals(selectedTags.size(), 3, "Only three tags should be selected");

--- a/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
@@ -3,6 +3,7 @@ package com.greencity.cucumber.steps;
 import com.greencity.cucumber.hooks.Hooks;
 import com.greencity.ui.elements.NewsTags;
 import com.greencity.ui.pages.CreateEditNewsPage;
+import com.greencity.ui.pages.econewspage.EcoNewsPage;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -12,6 +13,7 @@ import java.util.List;
 public class TagSelectionSteps {
     private final Hooks hooks;
     private CreateEditNewsPage createEditNewsPage;
+    private EcoNewsPage ecoNewsPage;
 
     public TagSelectionSteps(Hooks hooks) {
         this.hooks = hooks;
@@ -21,42 +23,75 @@ public class TagSelectionSteps {
         return new CreateEditNewsPage(hooks.getDriver());
     }
 
+    private EcoNewsPage getEcoNewsPage() {
+        return new EcoNewsPage(hooks.getDriver());
+    }
+
     @Given("User opens the Create News page")
+    public void userOpensEcoNewsPage() {
+        hooks.getDriver().get(hooks.getTestValueProvider().getBaseUIUrl() + "/news");
+        ecoNewsPage = getEcoNewsPage();
+    }
+
+    @Given("User opens the CreateEditNews page")
     public void userIsOnCreateNewsPage() {
         hooks.getDriver().get(hooks.getTestValueProvider().getBaseUIUrl() + "/news/create-news");
         createEditNewsPage = getCreateEditNewsPage();
     }
 
-    @When("User selects the first tag")
-    public void selectFirstTag() {
-        createEditNewsPage = getCreateEditNewsPage();
-        createEditNewsPage.clickTag(NewsTags.NEWS_TAG);
+    @When("User clicks Create News button")
+    public void userClicksCreateNewsButton() {
+        ecoNewsPage = getEcoNewsPage();
+        createEditNewsPage = ecoNewsPage.clickCreateNewsButton();
     }
 
-    @When("User selects the second tag")
-    public void selectSeconTag() {
+    @When("User selects the {string} tag")
+    public void userSelectsDynamicTag(String tag) {
         createEditNewsPage = getCreateEditNewsPage();
-        createEditNewsPage.clickTag(NewsTags.EVENTS_TAG);
+        createEditNewsPage.clickTag(NewsTags.getByName(tag));
     }
 
-    @When("User selects the third tag")
-    public void selectThirdTag() {
+    @When("User fills in the Title with {string}")
+    public void userFillsTitle(String title) {
         createEditNewsPage = getCreateEditNewsPage();
-        createEditNewsPage.clickTag(NewsTags.EDUCATION_TAG);
+        createEditNewsPage.enterTitle(title);
     }
 
-    @When("User tries to select the fourth tag")
-    public void selectFourthTag() {
+    @When("User fills in the Main Text with {string}")
+    public void userFillsMainText(String text) {
         createEditNewsPage = getCreateEditNewsPage();
-        createEditNewsPage.clickTag(NewsTags.ADS_TAG);
-
+        createEditNewsPage.enterContent(text);
     }
 
-    @Then("User should see only 3 tags selected")
-    public void verifyOnlyThreeTagsSelected() {
+    @When("User clicks Publish button")
+    public void userClicksPublish() {
         createEditNewsPage = getCreateEditNewsPage();
-        List<String> selectedTags = createEditNewsPage.getSelectedTags();
-        hooks.getSoftAssert().assertEquals(selectedTags.size(), 3, "Only three tags should be selected");
+        createEditNewsPage.clickPublish();
+    }
+
+    @Then("The 'Initiatives' tag is not selected")
+    public void initiativesTagIsNotSelected() {
+        createEditNewsPage = getCreateEditNewsPage();
+        hooks.getSoftAssert().assertFalse(createEditNewsPage.getSelectedTags().contains(NewsTags.INITIATIVES_TAG),
+                "The 'Initiatives' tag should not be selected");
+    }
+
+
+    @Then("News is published with the {string} tag")
+    public void newsPublishedWithOneTag(String tag) {
+        ecoNewsPage = getEcoNewsPage();
+        List<String> publishedTags = ecoNewsPage.getSelectedTags();
+        hooks.getSoftAssert().assertEquals(publishedTags.size(), 1, "News should be published with one tag");
+        hooks.getSoftAssert().assertTrue(publishedTags.contains(tag), "Published tag should be: " + tag);
+    }
+
+    @Then("News is published with the {string}, {string}, and {string} tags")
+    public void newsPublishedWithThreeTags(String tag1, String tag2, String tag3) {
+        ecoNewsPage = getEcoNewsPage();
+        List<String> publishedTags = ecoNewsPage.getSelectedTags();
+        List<String> expected = List.of(tag1, tag2, tag3);
+        hooks.getSoftAssert().assertTrue(publishedTags.containsAll(expected),
+                "Published tags should contain all: " + expected);
     }
 
 }

--- a/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
@@ -8,8 +8,6 @@ import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 
-import java.util.List;
-
 public class TagSelectionSteps {
     private final Hooks hooks;
     private CreateEditNewsPage createEditNewsPage;
@@ -69,29 +67,24 @@ public class TagSelectionSteps {
         createEditNewsPage.clickPublish();
     }
 
-    @Then("The 'Initiatives' tag is not selected")
-    public void initiativesTagIsNotSelected() {
+    @Then("The {string} tag is not selected")
+    public void tagIsNotSelected(String ta) {
         createEditNewsPage = getCreateEditNewsPage();
-        hooks.getSoftAssert().assertFalse(createEditNewsPage.getSelectedTags().contains(NewsTags.INITIATIVES_TAG),
-                "The 'Initiatives' tag should not be selected");
+        hooks.getSoftAssert().assertEquals(createEditNewsPage.getSelectedTagCount(),3, "There should be three tags selected");
+        hooks.getSoftAssert().assertFalse(createEditNewsPage.isTagSelected(NewsTags.getByName(ta)), "The tag " + ta + " should not be selected");
     }
 
 
-    @Then("News is published with the {string} tag")
-    public void newsPublishedWithOneTag(String tag) {
+    @Then("News is published with the one tag")
+    public void newsPublishedWithOneTag() {
         ecoNewsPage = getEcoNewsPage();
-        List<String> publishedTags = ecoNewsPage.getSelectedTags();
-        hooks.getSoftAssert().assertEquals(publishedTags.size(), 1, "News should be published with one tag");
-        hooks.getSoftAssert().assertTrue(publishedTags.contains(tag), "Published tag should be: " + tag);
+        hooks.getSoftAssert().assertEquals(ecoNewsPage.getSelectedTagCount(), 1, "News should be published with one tag selected");
     }
 
-    @Then("News is published with the {string}, {string}, and {string} tags")
-    public void newsPublishedWithThreeTags(String tag1, String tag2, String tag3) {
+    @Then("News is published with three tags")
+    public void newsPublishedWithThreeTags() {
         ecoNewsPage = getEcoNewsPage();
-        List<String> publishedTags = ecoNewsPage.getSelectedTags();
-        List<String> expected = List.of(tag1, tag2, tag3);
-        hooks.getSoftAssert().assertTrue(publishedTags.containsAll(expected),
-                "Published tags should contain all: " + expected);
+        hooks.getSoftAssert().assertEquals(ecoNewsPage.getSelectedTagCount(), 3, "News should be published with three tags selected");
     }
 
 }

--- a/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/TagSelectionSteps.java
@@ -54,11 +54,6 @@ public class TagSelectionSteps {
 
     @Then("User should see only 3 tags selected")
     public void verifyOnlyThreeTagsSelected() {
-        try {
-            Thread.sleep(1000);
-        } catch (InterruptedException e) {
-            throw new RuntimeException(e);
-        }
         createEditNewsPage = getCreateEditNewsPage();
         List<String> selectedTags = createEditNewsPage.getSelectedTags();
         hooks.getSoftAssert().assertEquals(selectedTags.size(), 3, "Only three tags should be selected");

--- a/src/test/resources/features/tag_selection.feature
+++ b/src/test/resources/features/tag_selection.feature
@@ -12,7 +12,7 @@ Feature: Tag Selection
     And User fills in the Main Text with "Test content with 20 chars"
     And User selects the "News" tag
     And User clicks Publish button
-    Then News is published with the "News" tag
+    Then News is published with the one tag
 
 
   Scenario: User can publish news with three tags
@@ -24,7 +24,7 @@ Feature: Tag Selection
     And User selects the "Events" tag
     And User selects the "Education" tag
     And User clicks Publish button
-    Then News is published with the "News", "Events", and "Education" tags
+    Then News is published with three tags
 
 
   Scenario: User cannot select more than three tags
@@ -38,5 +38,5 @@ Feature: Tag Selection
     And User selects the "Initiatives" tag
     Then The "Initiatives" tag is not selected
     When User clicks Publish button
-    Then News is published with the "News", "Events", and "Education" tags
-    And The "Initiatives" tag is not selected
+    Then News is published with three tags
+

--- a/src/test/resources/features/tag_selection.feature
+++ b/src/test/resources/features/tag_selection.feature
@@ -7,9 +7,9 @@ Feature: Tag Selection
     Given the base user is registered and logged into the GreenCity system
 
   Scenario: User can select up to 3 tags
-                Given User opens the Create News page
-                When User selects the first tag
-                And User selects the second tag
-                And User selects the third tag
-                And User tries to select the fourth tag
-                Then User should see only 3 tags selected
+    Given User opens the Create News page
+    When User selects the first tag
+    And User selects the second tag
+    And User selects the third tag
+    And User tries to select the fourth tag
+    Then User should see only 3 tags selected

--- a/src/test/resources/features/tag_selection.feature
+++ b/src/test/resources/features/tag_selection.feature
@@ -1,4 +1,3 @@
-@tagSelection
 Feature: Tag Selection
 
   Description: Verify that the basic functionality of the tag selection feature works as expected.
@@ -6,10 +5,38 @@ Feature: Tag Selection
   Background:
     Given the base user is registered and logged into the GreenCity system
 
-  Scenario: User can select up to 3 tags
+  Scenario: User can publish news with one tag
     Given User opens the Create News page
-    When User selects the first tag
-    And User selects the second tag
-    And User selects the third tag
-    And User tries to select the fourth tag
-    Then User should see only 3 tags selected
+    When User clicks Create News button
+    And User fills in the Title with "Test"
+    And User fills in the Main Text with "Test content with 20 chars"
+    And User selects the "News" tag
+    And User clicks Publish button
+    Then News is published with the "News" tag
+
+
+  Scenario: User can publish news with three tags
+    Given User opens the Create News page
+    When User clicks Create News button
+    And User fills in the Title with "Test"
+    And User fills in the Main Text with "Test content with 20 chars"
+    And User selects the "News" tag
+    And User selects the "Events" tag
+    And User selects the "Education" tag
+    And User clicks Publish button
+    Then News is published with the "News", "Events", and "Education" tags
+
+
+  Scenario: User cannot select more than three tags
+    Given User opens the Create News page
+    When User clicks Create News button
+    And User fills in the Title with "Test"
+    And User fills in the Main Text with "Test content with 20 chars"
+    And User selects the "News" tag
+    And User selects the "Events" tag
+    And User selects the "Education" tag
+    And User selects the "Initiatives" tag
+    Then The "Initiatives" tag is not selected
+    When User clicks Publish button
+    Then News is published with the "News", "Events", and "Education" tags
+    And The "Initiatives" tag is not selected


### PR DESCRIPTION
Tag selection test update

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added the ability to retrieve and verify selected news tags on the Eco News page.
  * Enhanced tag selection and verification steps in news creation workflows.
  * Expanded test scenarios to cover publishing news with one or three tags and preventing selection of more than three tags.
  * Introduced dynamic tag selection by name and added steps for filling news title, main text, and publishing.
  * Added methods to check tag selection status and count selected tags in news pages.

* **Bug Fixes**
  * Improved tag selection logic to ensure a maximum of three tags can be selected when creating news.

* **Tests**
  * Updated and extended test steps and scenarios for more comprehensive tag selection and publishing validation.
  * Restructured feature files to separate scenarios for single, multiple, and restricted tag selection cases.
  * Refined test step definitions to better distinguish between news listing and creation pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->