### PR TITLE
Gherkin

### DIFF
--- a/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
@@ -94,5 +94,18 @@ public class NewsPage extends AbstractNewsPage {
         driver.findElement(deleteButton).click();
         return new WarningModalDialog(driver, driver.findElement(dialogPopUpRoot));
     }
+
+    public void clickButtonByText(String text) {
+        switch (text) {
+            case "Edit":
+                clickEditNewsButton();
+                break;
+            case "Delete":
+                clickDeleteButton();
+                break;
+            default:
+                throw new RuntimeException("Unsupported text: " + text);
+        }
+    }
 }
 

--- a/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
+++ b/src/main/java/com/greencity/ui/pages/abstractNewsPage/NewsPage.java
@@ -95,14 +95,12 @@ public class NewsPage extends AbstractNewsPage {
         return new WarningModalDialog(driver, driver.findElement(dialogPopUpRoot));
     }
 
-    public void clickButtonByText(String text) {
+    public Object clickButtonByText(String text) {
         switch (text) {
             case "Edit":
-                clickEditNewsButton();
-                break;
+               return clickEditNewsButton();
             case "Delete":
-                clickDeleteButton();
-                break;
+                return clickDeleteButton();
             default:
                 throw new RuntimeException("Unsupported text: " + text);
         }

--- a/src/test/java/com/greencity/cucumber/steps/CreateEditSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/CreateEditSteps.java
@@ -6,6 +6,10 @@ import com.greencity.ui.pages.CreateEditNewsPage;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
+import io.qameta.allure.Owner;
+import io.qameta.allure.Step;
+
+import java.io.File;
 
 
 public class CreateEditSteps {
@@ -113,4 +117,21 @@ public class CreateEditSteps {
         hooks.getSoftAssert().assertTrue(getCreateEditNewsPage().getDescriptionWarningTextarea().isDisplayed(),"In the text area, there must be description warning");
     }
 
+    @And("the user uploads an image larger than 10MB")
+    @Step("Upload image larger than 10MB")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theUserUploadsAnImageLargerThanMB() {
+        File largeImage = new File("src/test/resources/imagesForTests/15mb.jpg");
+        getCreateEditNewsPage().uploadImage(largeImage.getAbsolutePath());
+    }
+
+    @And("the user clicks \"Edit\"")
+    @Step("Click \"Edit\" button in the news post")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theUserClicks() {
+        getCreateEditNewsPage()
+                .clickEdit()
+                .getHeader()
+                .goToMySpace();
+    }
 }

--- a/src/test/java/com/greencity/cucumber/steps/EcoNewsSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/EcoNewsSteps.java
@@ -29,7 +29,6 @@ public class EcoNewsSteps {
     private EcoNewsPage ecoNewsPage;
     private CreateEditNewsPage createEditNewsPage;
 
-
     public EcoNewsSteps(Hooks hooks) {
         this.hooks = hooks;
         this.softAssert = hooks.getSoftAssert();
@@ -46,11 +45,6 @@ public class EcoNewsSteps {
     @Issue("192")
     public void userAIsLoggedIn() {
         loginViaLocalStorage(hooks.getDriver(), hooks.getLocalStorageJS(), hooks.getTestValueProvider());
-//        hooks.getLocalStorageJS().setItemLocalStorage("accessToken", hooks.getTestValueProvider().getLocalStorageAccessToken());
-//        hooks.getLocalStorageJS().setItemLocalStorage("userId", hooks.getTestValueProvider().getLocalStorageUserId().toString());
-//        hooks.getLocalStorageJS().setItemLocalStorage("refreshToken", hooks.getTestValueProvider().getLocalStorageRefreshToken());
-//        hooks.getLocalStorageJS().setItemLocalStorage("name", hooks.getTestValueProvider().getLocalStorageName());
-//        hooks.getDriver().navigate().refresh();
     }
 
     @And("User A creates a new news post with title {string} and tag {string}")
@@ -234,5 +228,21 @@ public class EcoNewsSteps {
         String header = createEditNewsPage.getTitleHeader().getText().toLowerCase();
         softAssert.assertTrue(header.contains(wordEn.toLowerCase()) || header.contains(wordUa.toLowerCase()),
                 "Page title doesn't contain expected text: " + header);
+    }
+
+
+    @And("User creates a new news post with title {string} and tag {string}")
+    @Description("Create a news post with specified title and tag")
+    @Owner("Prykhodchenko Oleksandra")
+    public void userCreatesANewNewsPostWithTitleAndTag(String arg0, String arg1) {
+        userACreatesNews(arg0, arg1);
+    }
+
+
+    @And("user navigates to the {string} Page")
+    public void userNavigatesToThePage(String arg0) {
+        homePage
+                .getHeader()
+                .goToMySpace();
     }
 }

--- a/src/test/java/com/greencity/cucumber/steps/EcoNewsSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/EcoNewsSteps.java
@@ -240,9 +240,13 @@ public class EcoNewsSteps {
 
 
     @And("user navigates to the {string} Page")
-    public void userNavigatesToThePage(String arg0) {
-        homePage
-                .getHeader()
-                .goToMySpace();
+    public void userNavigatesToThePage(String pageName) {
+        switch (pageName) {
+            case "My space":
+                    homePage.getHeader().goToMySpace();
+                    break;
+            default:
+                    throw new RuntimeException("Unsupported page: " + pageName);
     }
+}
 }

--- a/src/test/java/com/greencity/cucumber/steps/MySpaceSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/MySpaceSteps.java
@@ -1,15 +1,24 @@
 package com.greencity.cucumber.steps;
 
 import com.greencity.cucumber.hooks.Hooks;
+import com.greencity.ui.pages.homepage.HomePage;
 import com.greencity.ui.pages.myspacepage.MySpacePage;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
+import io.qameta.allure.Owner;
+import io.qameta.allure.Step;
+import org.testng.asserts.SoftAssert;
 
 public class MySpaceSteps {
     private final Hooks hooks;
+    private final SoftAssert softAssert;
 
     private MySpacePage mySpacePage;
     public MySpaceSteps(Hooks hooks) {
         this.hooks = hooks;
+        this.softAssert = hooks.getSoftAssert();
+        this.mySpacePage = new MySpacePage(hooks.getDriver());
 
     }
 
@@ -26,5 +35,32 @@ public class MySpaceSteps {
         mySpacePage = getMySpacePage();
         hooks.getSoftAssert().assertEquals(mySpacePage.getMySpaceDescription().getText(),
                 "Welcome to My Habits. It seems you don’t have any habits in progress. Let’s start to acquire a new one!");
+    }
+
+    @Given("the user navigates to {string} tab")
+    @Step("Navigate to '{0}' tab in My Space")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theUserNavigatesTo(String arg0) {
+        mySpacePage
+                .clickTabsByText(arg0);
+    }
+
+    @And("the user opens the first news post")
+    @Step("Open the first news post")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theUserOpensTheFirstNewsPost() {
+        mySpacePage.clickFirstNew();
+    }
+
+    @Then("the image should not be updated")
+    @Step("Verify the image was not updated")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theImageShouldNotBeUpdated() {
+        theUserNavigatesTo("My news");
+        softAssert.assertTrue(mySpacePage
+                .clickFirstNew()
+                .getNewsImage()
+                .getAttribute("src")
+                .contains("assets/img/icon/econews/news-default-large.png"), "Image was changed");
     }
 }

--- a/src/test/java/com/greencity/cucumber/steps/NewsPageSteps.java
+++ b/src/test/java/com/greencity/cucumber/steps/NewsPageSteps.java
@@ -1,0 +1,27 @@
+package com.greencity.cucumber.steps;
+
+import com.greencity.cucumber.hooks.Hooks;
+import com.greencity.ui.pages.abstractNewsPage.NewsPage;
+import io.cucumber.java.en.And;
+import io.qameta.allure.Owner;
+import io.qameta.allure.Step;
+import org.testng.asserts.SoftAssert;
+
+public class NewsPageSteps {
+    private final Hooks hooks;
+    private final SoftAssert softAssert;
+    private final NewsPage newsPage;
+
+
+    public NewsPageSteps(Hooks hooks) {
+        this.hooks = hooks;
+        this.softAssert = hooks.getSoftAssert();
+        this.newsPage = new NewsPage(hooks.getDriver());
+    }
+    @And("the user clicks \"Edit news\"")
+    @Step("Click \"Edit news\" to attempt saving changes")
+    @Owner("Prykhodchenko Oleksandra")
+    public void theUserClicks() {
+        newsPage.clickEditNewsButton();
+    }
+}

--- a/src/test/resources/features/ecoNewsFeatures/validation_edit_page_image_size.feature
+++ b/src/test/resources/features/ecoNewsFeatures/validation_edit_page_image_size.feature
@@ -1,0 +1,20 @@
+Feature: Edit News Image Upload Validation
+
+  As an authenticated user
+  I want to ensure the edit news form validates image size correctly
+  So that I cannot upload images larger than 10MB
+
+  Background:
+    Given the user is logged in to the GreenCity system
+    And User creates a new news post with title "Test News" and tag "Education"
+    And user navigates to the "My space" Page
+
+  @EditNews @Negative @Image @Validation @Issue40
+  Scenario: User cannot upload image larger than 10MB when editing a news post
+    Given the user navigates to "My news" tab
+    And the user opens the first news post
+    And the user clicks "Edit news"
+    And the user uploads an image larger than 10MB
+    And the user clicks "Edit"
+    Then the image should not be updated
+    And  User A deletes the created news post


### PR DESCRIPTION
added NewsPageSteps and validation_edit_page_image_size.feature

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced test steps for uploading images larger than 10MB during news post editing, with validation that oversized images are not accepted.
  * Added step definitions for navigating to specific tabs and pages, opening news posts, and initiating edit actions in test scenarios.
  * Created a new feature file to validate image size restrictions during news post editing.

* **Bug Fixes**
  * Improved test reliability by replacing manual local storage setup with a dedicated login method in authentication steps.

* **Refactor**
  * Enhanced test step classes to use shared page object instances for consistency and maintainability.

* **Tests**
  * Added new Cucumber step definitions and a feature file to cover negative scenarios for image upload size validation in news editing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->